### PR TITLE
Fix crash when double-clicking a glyph to open the editor

### DIFF
--- a/src/components/grid_scroll_handler.rs
+++ b/src/components/grid_scroll_handler.rs
@@ -413,12 +413,16 @@ where
         mut element: Mut<'_, Self::Element>,
         app_state: &mut State,
     ) -> MessageResult<Action> {
-        // Check for our own scroll/keyboard actions first.
-        if let Some(action) =
-            message.take_message::<GridScrollAction>()
-        {
-            (self.on_action)(app_state, *action);
-            return MessageResult::Action(Action::default());
+        // Only take our own actions when the message has reached
+        // this widget (remaining path exhausted). Child-bound
+        // messages still have path segments and must be delegated.
+        if message.remaining_path().is_empty() {
+            if let Some(action) =
+                message.take_message::<GridScrollAction>()
+            {
+                (self.on_action)(app_state, *action);
+                return MessageResult::Action(Action::default());
+            }
         }
 
         // Not ours — delegate to child (e.g. glyph cell clicks).


### PR DESCRIPTION
GridScrollHandlerView::message() was calling take_message() unconditionally, but take_message() debug-asserts that the message path is fully consumed (i.e. the message has reached its target widget). When a GlyphCellAction click was routed through the scroll handler on its way to a child widget, the path was not yet exhausted, causing a panic.

Fix: guard take_message with remaining_path().is_empty() so scroll/ keyboard actions are only consumed when the message is actually targeting GridScrollWidget itself. Child-bound messages are passed straight through to the inner view.

Closes #13